### PR TITLE
Support .NET Core csproj files

### DIFF
--- a/LangVersionFixer/Program.cs
+++ b/LangVersionFixer/Program.cs
@@ -79,7 +79,9 @@ namespace LangVersionFixer
 
                 var document = file.ReadXmlDocument();
 
-                document.AddLangVersionElement(@namespace, langVersion);
+                var isNetCore = document.Root?.Attribute("Sdk") != null;
+
+                document.AddLangVersionElement(isNetCore ? "" : @namespace, langVersion);
 
                 if (cleanDocument)
                 {

--- a/LangVersionFixer/Program.cs
+++ b/LangVersionFixer/Program.cs
@@ -77,9 +77,9 @@ namespace LangVersionFixer
 
             foreach (var file in files)
             {
-                var document = file.ReadXmlDocument();
+                Console.WriteLine($"Processing {file.Name}.");
 
-                Console.WriteLine($"Processed {file.Name}.");
+                var document = file.ReadXmlDocument();
 
                 document.AddLangVersionElement(@namespace, langVersion);
 

--- a/LangVersionFixer/Program.cs
+++ b/LangVersionFixer/Program.cs
@@ -71,8 +71,6 @@ namespace LangVersionFixer
 
             var files = directory.EnumerateFiles("*.csproj", SearchOption.AllDirectories);
 
-            var settings = new XmlWriterSettings { Indent = true };
-
             Console.WriteLine($"Setting LangVersion to {langVersion} in all projects under {directory.FullName}...");
 
             foreach (var file in files)
@@ -87,6 +85,12 @@ namespace LangVersionFixer
                 {
                     document.CleanUpEmptyElements();
                 }
+
+                var settings = new XmlWriterSettings
+                {
+                    Indent = true,
+                    OmitXmlDeclaration = document.Declaration == null
+                };
 
                 using (var writer = XmlWriter.Create(file.FullName, settings))
                 {

--- a/LangVersionFixer/Program.cs
+++ b/LangVersionFixer/Program.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Xml;


### PR DESCRIPTION
These XML files do not use any XML namespace, nor do they tend to start with an XML declaration.

Before this PR, running the tool would give the following error and stop:

```text
Unhandled Exception: System.InvalidOperationException: This operation would create an incorrectly structured document.
   at System.Xml.Linq.XDocument.ValidateDocument(XNode previous, XmlNodeType allowBefore, XmlNodeType allowAfter)
   at System.Xml.Linq.XDocument.ValidateNode(XNode node, XNode previous)
   at System.Xml.Linq.XContainer.AddNodeSkipNotify(XNode n)
   at System.Xml.Linq.XContainer.AddContentSkipNotify(Object content)
   at System.Xml.Linq.XContainer.Add(Object content)
   at LangVersionFixer.Program.AddLangVersionElement(XContainer document, XNamespace namespace, String langVersion)
   at LangVersionFixer.Program.FixLangVersion(DirectoryInfo directory, String langVersion, Boolean cleanDocument)
   at LangVersionFixer.Program.Main(String[] args)
```

Thanks for sharing this tool. Even with making this PR, I still saved a bunch of mind-numbing time.